### PR TITLE
Add timeout and fix preparation bug

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,12 +11,14 @@ cppcoreguidelines-*,
 concurrency-*,
 google-*,
 hicpp-*,
+-hicpp-braces-around-statements,
 llvm-*,
 -llvm-header-guard,
 misc-*,
 -misc-non-private-member-variables-in-classes,
 modernize-*,
 readability-*,
+-readability-braces-around-statements,
 performance-*,'
 WarningsAsErrors: ''
 HeaderFilterRegex: '(include|src|test)/.*\.hpp$'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -143,6 +143,12 @@
     "variant": "cpp",
     "shared_mutex": "cpp",
     "bitset": "cpp",
-    "regex": "cpp"
+    "regex": "cpp",
+    "csignal": "cpp",
+    "strstream": "cpp",
+    "complex": "cpp",
+    "cfenv": "cpp",
+    "typeindex": "cpp",
+    "valarray": "cpp"
   },
 }

--- a/include/benchmark/benchmarker.hpp
+++ b/include/benchmark/benchmarker.hpp
@@ -65,33 +65,43 @@ class Benchmarker
    * @brief Construct a new Benchmarker object.
    *
    * @param bench_target a reference to an actual target implementation.
+   * @param target_name the name of a benchmarking target.
    * @param ops_engine a reference to a operation generator.
-   * @param exec_num the total number of executions for benchmarking.
+   * @param exec_num the number of executions of each worker.
    * @param thread_num the number of worker threads.
    * @param random_seed a base random seed.
    * @param measure_throughput a flag for measuring throughput (true) or latency (false).
    * @param output_as_csv a flag to output benchmarking results as CSV or TEXT.
+   * @param timeout_in_sec seconds to timeout.
+   * @param target_latency a set of percentiles for measuring latency.
    */
   Benchmarker(  //
       Target &bench_target,
+      const std::string &target_name,
       OperationEngine &ops_engine,
       const size_t exec_num,
       const size_t thread_num,
       const size_t random_seed,
       const bool measure_throughput,
       const bool output_as_csv,
-      const std::string &target_name = "NO-NAME TARGET",
+      const size_t timeout_in_sec,
       const char *target_latency = kDefaultLatency)
-      : total_exec_num_{exec_num},
+      : exec_num_{exec_num},
         thread_num_{thread_num},
-        total_sample_num_{(total_exec_num_ < kMaxLatencyNum) ? total_exec_num_ : kMaxLatencyNum},
         random_seed_{random_seed},
         measure_throughput_{measure_throughput},
         output_as_csv_{output_as_csv},
         bench_target_{bench_target},
-        ops_engine_{ops_engine}
+        ops_engine_{ops_engine},
+        timeout_in_sec_{timeout_in_sec}
   {
     if (!measure_throughput_) {
+      // check the number of samples is valid
+      const auto total_exec_num = exec_num_ * thread_num_;
+      if (total_exec_num < kMaxLatencyNum) {
+        total_sample_num_ = total_exec_num;
+      }
+
       // prepare percentile latency
       constexpr size_t kDefaultCapacity = 32;
       target_latency_.reserve(kDefaultCapacity);
@@ -154,11 +164,9 @@ class Benchmarker
     // create workers in each thread
     std::mt19937_64 rand{random_seed_};
     for (size_t i = 0; i < thread_num_; ++i) {
-      const size_t n = (total_exec_num_ + i) / thread_num_;
-
       std::promise<Result_p> p{};
       futures.emplace_back(p.get_future());
-      std::thread{&Benchmarker::RunWorker, this, std::move(p), n, rand()}.detach();
+      std::thread{&Benchmarker::RunWorker, this, std::move(p), rand()}.detach();
     }
 
     // wait for all workers to be created
@@ -179,6 +187,11 @@ class Benchmarker
     std::vector<Result_p> results{};
     results.reserve(thread_num_);
     for (auto &&future : futures) {
+      const auto status = future.wait_for(timeout_in_sec_);
+      if (status != std::future_status::ready) {
+        Log("...Interrupting workers.");
+        is_running_.store(false, std::memory_order_relaxed);
+      }
       results.emplace_back(future.get());
     }
 
@@ -215,13 +228,11 @@ class Benchmarker
    * @brief Run a worker thread to measure throughput or latency.
    *
    * @param p a promise of a worker pointer that holds benchmarking results.
-   * @param exec_num the number of executions for this worker.
    * @param random_seed a random seed.
    */
   void
   RunWorker(  //
       std::promise<Result_p> p,
-      const size_t exec_num,
       const size_t random_seed)
   {
     // create a lock to stop a main thread
@@ -229,7 +240,7 @@ class Benchmarker
 
     // prepare a worker
     Worker_p worker{nullptr};
-    const auto &operations = ops_engine_.Generate(exec_num, random_seed);
+    const auto &operations = ops_engine_.Generate(exec_num_, random_seed);
     worker = std::make_unique<Worker_t>(bench_target_, std::move(operations));
 
     // unlock the shared mutex and wait other workers
@@ -241,9 +252,9 @@ class Benchmarker
 
     // start when all workers are ready for benchmarking
     if (measure_throughput_) {
-      worker->MeasureThroughput();
+      worker->MeasureThroughput(is_running_);
     } else {
-      worker->MeasureLatency();
+      worker->MeasureLatency(is_running_);
     }
 
     p.set_value_at_thread_exit(worker->MoveMeasurements());
@@ -257,13 +268,15 @@ class Benchmarker
   void
   LogThroughput(const std::vector<Result_p> &results) const
   {
+    size_t exec_num = 0;
     size_t avg_nano_time = 0;
     for (auto &&result : results) {
+      exec_num += result->GetTotalExecNum();
       avg_nano_time += result->GetTotalExecTime();
     }
     avg_nano_time /= thread_num_;
 
-    const auto throughput = total_exec_num_ / (avg_nano_time / 1E9);
+    const auto throughput = exec_num / (avg_nano_time / 1E9);
 
     if (output_as_csv_) {
       std::cout << throughput << std::endl;
@@ -322,14 +335,11 @@ class Benchmarker
    * Internal member variables
    *##################################################################################*/
 
-  /// the total number of executions for benchmarking
-  const size_t total_exec_num_{};
+  /// the number of executions of each worker
+  const size_t exec_num_{};
 
   /// the number of worker threads
   const size_t thread_num_{};
-
-  /// the total number of sampled execution time for computing percentiled latency
-  const size_t total_sample_num_{};
 
   /// a base random seed
   const size_t random_seed_{};
@@ -339,6 +349,9 @@ class Benchmarker
 
   /// a flat to output measured results as CSV or TEXT
   const bool output_as_csv_{};
+
+  /// the total number of sampled execution time for computing percentiled latency
+  size_t total_sample_num_{kMaxLatencyNum};
 
   /// targets for calculating parcentile latency
   std::vector<double> target_latency_{};
@@ -357,6 +370,12 @@ class Benchmarker
 
   /// a conditional variable for waking up worker threads
   std::condition_variable cond_{};
+
+  /// a flag for interrupting workers.
+  std::atomic_bool is_running_{true};
+
+  /// seconds to timeout.
+  std::chrono::seconds timeout_in_sec_{};
 
   /// a flag for waking up worker threads
   bool ready_for_benchmarking_{false};

--- a/include/benchmark/component/measurements.hpp
+++ b/include/benchmark/component/measurements.hpp
@@ -87,6 +87,16 @@ class Measurements
   }
 
   /**
+   * @return the total number of executed operations.
+   */
+  [[nodiscard]] auto
+  GetTotalExecNum() const  //
+      -> size_t
+  {
+    return total_exec_num_;
+  }
+
+  /**
    * @return total execution time.
    */
   [[nodiscard]] auto
@@ -94,6 +104,17 @@ class Measurements
       -> size_t
   {
     return total_exec_time_nano_;
+  }
+
+  /**
+   * @brief Set the total number of executed operations.
+   *
+   * @param total_exec_num the total number of executed operations.
+   */
+  void
+  SetTotalExecNum(const size_t total_exec_num)
+  {
+    total_exec_num_ = total_exec_num;
   }
 
   /**
@@ -122,6 +143,9 @@ class Measurements
   /*####################################################################################
    * Internal member variables
    *##################################################################################*/
+
+  /// the number of executed operations.
+  size_t total_exec_num_{0};
 
   /// total execution time [ns]
   size_t total_exec_time_nano_{0};

--- a/test/benchmarker_test.cpp
+++ b/test/benchmarker_test.cpp
@@ -62,16 +62,18 @@ class BenchmarkerFixture : public ::testing::Test
   void
   VerifyMeasureThroughput(const size_t thread_num)
   {
-    benchmarker_ = std::make_unique<Benchmarker_t>(target_, ops_engine_, kExecNum, thread_num,
-                                                   kRandomSeed, true, false);
+    benchmarker_ =
+        std::make_unique<Benchmarker_t>(target_, "Bench for testing", ops_engine_, kExecNum,
+                                        thread_num, kRandomSeed, kThroughput, kOutText, kTimeout);
     benchmarker_->Run();
   }
 
   void
   VerifyMeasureLatency(const size_t thread_num)
   {
-    benchmarker_ = std::make_unique<Benchmarker_t>(target_, ops_engine_, kExecNum, thread_num,
-                                                   kRandomSeed, false, false);
+    benchmarker_ =
+        std::make_unique<Benchmarker_t>(target_, "Bench for testing", ops_engine_, kExecNum,
+                                        thread_num, kRandomSeed, kLatency, kOutText, kTimeout);
     benchmarker_->Run();
   }
 
@@ -82,6 +84,10 @@ class BenchmarkerFixture : public ::testing::Test
 
   static constexpr size_t kExecNum = 1e6;
   static constexpr size_t kRandomSeed = 0;
+  static constexpr bool kThroughput = true;
+  static constexpr bool kLatency = false;
+  static constexpr bool kOutText = false;
+  static constexpr size_t kTimeout = 100;
 
   /*####################################################################################
    * Internal member variables

--- a/test/worker_test.cpp
+++ b/test/worker_test.cpp
@@ -63,8 +63,9 @@ class WorkerFixture : public ::testing::Test
   void
   VerifyMeasureThroughput()
   {
+    std::atomic_bool is_running{true};
     stopwatch_.Start();
-    worker_->MeasureThroughput();
+    worker_->MeasureThroughput(is_running);
     stopwatch_.Stop();
 
     // check the total execution time is reasonable
@@ -80,8 +81,9 @@ class WorkerFixture : public ::testing::Test
   void
   VerifyMeasureLatency()
   {
+    std::atomic_bool is_running{true};
     stopwatch_.Start();
-    worker_->MeasureLatency();
+    worker_->MeasureLatency(is_running);
     stopwatch_.Stop();
 
     // check random sampling is performed


### PR DESCRIPTION
- 一定時間でベンチマークを終了させる機能を追加．
    - これに伴い，実行回数の指定方法を全実行回数から各ワーカの実行回数へ変更．
- メインスレッドへの準備完了通知に`promise/future`を使用するように変更．